### PR TITLE
Example of read/write and object translation

### DIFF
--- a/light/__init__.py
+++ b/light/__init__.py
@@ -7,6 +7,8 @@ import gunicorn.app.base
 from gunicorn.six import iteritems
 
 from .framework import route_framework
+from . import backend
+from .drivers.disk import disk_driver
 
 
 def number_of_workers():
@@ -59,6 +61,9 @@ def main():
         'bind': '%s:%s' % (args.host, args.port),
         'workers': args.workers,
     }
+
+    # Instantiate the backend driver (TODO: Make this generic and a configurable)
+    backend.current_driver = disk_driver('./demo_db')
 
     # Create a Falcon app.
     app = falcon.API()

--- a/light/backend.py
+++ b/light/backend.py
@@ -1,0 +1,1 @@
+current_driver = None

--- a/light/drivers/disk.py
+++ b/light/drivers/disk.py
@@ -1,0 +1,49 @@
+import os
+import json
+import bson
+
+# A simple driver that uses a directory structure to manage
+# data objects as discrete text files containing JSON data
+
+class disk_driver(object):
+    def __init__(self, root_dir='.'):
+        self.root = root_dir
+
+        # If they provided the trailing slash, remove it
+        # for consistency
+        if self.root[-1] == '/':
+            self.root = self.root[:-1]
+
+        if not os.access('{root}'.format(root=self.root), os.W_OK):
+            os.mkdir(path='{root}'.format(root=self.root), mode=0o755)
+
+    # Indiscriminantly write the object back to disk. Overwrite any existing instance.
+    def store(self, set_name, obj):
+        if not os.access('{root}/{set_name}'.format(root=self.root, set_name=set_name), os.W_OK):
+            os.mkdir(path='{root}/{set_name}'.format(root=self.root, set_name=set_name), mode=0o755)
+        with open('{root}/{set_name}/{objid}.json'.format(root=self.root, set_name=set_name,
+                                                          objid=obj['id']), 'w') as objfh:
+            json.dump(obj, objfh)
+
+    # Given a set_name and objid, load the object identified by that objid. If it isn't present,
+    # return None
+    def load(self, set_name, objid):
+        if os.access('{root}/{set_name}/{objid}.json'.format(root=self.root, set_name=set_name,
+                                                             objid=str(objid)), os.R_OK):
+            with open('{root}/{set_name}/{objid}.json'.format(root=self.root, set_name=set_name,
+                                                              objid=str(objid)), 'r') as objfh:
+                obj = json.load(objfh)
+                return obj
+
+            return None
+
+    # Fetch all entities from a given set (given by set_name)
+    def get_all(self, set_name):
+        if not os.access('{root}/{set_name}'.format(root=self.root, set_name=set_name), os.W_OK):
+            return
+
+        with os.scandir('{root}/{set_name}'.format(root=self.root, set_name=set_name)) as dir_handle:
+            for d_ent in dir_handle:
+                if not d_ent.name.startswith('.') and d_ent.is_file():
+                    # Yields only the ObjectId portion of the name, wraps it in an ObjectId
+                    yield bson.ObjectId(d_ent.name.split('.')[0])

--- a/light/framework.py
+++ b/light/framework.py
@@ -9,6 +9,17 @@ class TestResource(object):
         """Handles all GET requests."""
         _test_resource_get(req, res)
 
+def load_driver(options):
+    # Dynamically find db driver among installed packages, and return it if it
+    # is found
+    for importer, pkgname, ispkg in pkgutil.walk_packages(['./light/drivers']):
+        if pkgname == options['dbdriver']:
+            full_pkg_name = 'drivers.{pkgname}'.format(pkgname=pkgname)
+            module = importer.find_module(full_pkg_name).load_module(full_pkg_name)
+            cobj = getattr(module, '{pkgname}_driver'.format(pkgname=pkgname))
+            cinst = cobj(options['dbstore'])
+            return cinst
+
 def route_framework(app):
     # Instantiate the TestResource class
     test_resource = TestResource()

--- a/light/light_types.py
+++ b/light/light_types.py
@@ -1,0 +1,53 @@
+import bson
+from . import backend
+
+# A base type for a document object that, at least, matches the following
+# signature:
+#
+# obj = {
+#   "id": ObjectId()
+# }
+#
+class LightDoc(object):
+    def __init__(self, set_name, oid=None):
+        self.valid = False
+        self.set_name = set_name
+
+        if oid == None:
+            # If instance construction gives us a NoneType oid, then we presume
+            # to be constructing a new entitiy, so give it a brand new ObjectId
+            self.data = {'id': bson.ObjectId()}
+        else:
+            # Otherwise, we are to perform a lookup and load of the designated
+            # object
+            self.load(oid)
+
+    def get_all(set_name, dtype):
+        for objid in backend.current_driver.get_all(set_name=set_name):
+            yield(dtype(oid=objid))
+
+    def save(self):
+        output_data = {}
+        for obj_key in self.data:
+            if isinstance(self.data[obj_key], bson.ObjectId):
+                output_data[obj_key] = str(self.data[obj_key])
+            else:
+                output_data[obj_key] = self.data[obj_key]
+        backend.current_driver.store(self.set_name, output_data)
+
+    def load(self, objid):
+        input_data = backend.current_driver.load(self.set_name, objid)
+
+        # Clear the instance data
+        self.data = {}
+
+        if input_data:
+            for obj_key in input_data:
+                if obj_key == 'id':
+                    self.data[obj_key] = bson.ObjectId(input_data[obj_key])
+                else:
+                    self.data[obj_key] = input_data[obj_key]
+            self.valid = True
+        else:
+            # Invalidate if the object doesn't exist
+            self.valid = False

--- a/light/light_types.py
+++ b/light/light_types.py
@@ -1,6 +1,48 @@
 import bson
 from . import backend
 
+class LightField(object):
+    def __init__(self, init=None, required=False, pk=False, unique=False):
+        self.required = required
+        self.pk = pk
+        self.unique = unique
+        self.assign(init)
+        self.field_name = type(self).__name__
+
+    def val(self):
+        return self.value
+
+    def assign(self, val):
+        self.value = val
+        return val
+
+    def __str__(self):
+        return str(self.val())
+
+class LightStr(LightField):
+    def __init__(self, init=None, required=False, pk=False, unique=False):
+        super(LightStr, self).__init__(init, required, pk, unique)
+
+    def assign(self, val):
+        assert(isinstance(val, str))
+        super(LightStr, self).assign(val)
+
+class LightInt(LightField):
+    def __init__(self, init=None, required=False, pk=False, unique=False):
+        super(LightInt, self).__init__(init, required, pk, unique)
+
+    def assign(self, val):
+        assert(isinstance(val, int))
+        super(LightInt, self).assign(val)
+
+class LightBool(LightField):
+    def __init__(self, init=None, required=False, pk=False, unique=False):
+        super(LightBool, self).__init__(init, required, pk, unique)
+
+    def assign(self, val):
+        assert(isinstance(val, bool))
+        super(LightBool, self).assign(val)
+
 # A base type for a document object that, at least, matches the following
 # signature:
 #

--- a/light/light_types.py
+++ b/light/light_types.py
@@ -9,9 +9,9 @@ from . import backend
 # }
 #
 class LightDoc(object):
-    def __init__(self, set_name, oid=None):
+    def __init__(self, oid=None):
         self.valid = False
-        self.set_name = set_name
+        self.set_name = type(self).set_name
 
         if oid == None:
             # If instance construction gives us a NoneType oid, then we presume

--- a/light/photons/Sources.py
+++ b/light/photons/Sources.py
@@ -22,7 +22,7 @@ class Source(LightDoc):
         if oid == None:
             # If oid is None, presume we're creating a new Source object
             #
-            # Populate Source-specific attributes, not it LightDoc
+            # Populate Source-specific attributes, not in LightDoc
             self.data['active'] = active
             self.data['source_name'] = source_name
 

--- a/light/photons/Sources.py
+++ b/light/photons/Sources.py
@@ -17,7 +17,7 @@ resources = ["SourceSet","SourceItem"]
 class Source(LightDoc):
     set_name = 'sources'
     def __init__(self, source_name=None, active=True, oid=None):
-        super(Source, self).__init__(set_name=Source.set_name, oid=oid)
+        super(Source, self).__init__(oid=oid)
 
         if oid == None:
             # If oid is None, presume we're creating a new Source object

--- a/light/photons/Sources.py
+++ b/light/photons/Sources.py
@@ -1,7 +1,7 @@
 import falcon
 import json
 from bson import ObjectId
-from light.light_types import LightDoc
+from light.light_types import LightDoc, LightField, LightStr, LightInt, LightBool
 
 resources = ["SourceSet","SourceItem"]
 
@@ -16,20 +16,8 @@ resources = ["SourceSet","SourceItem"]
 #
 class Source(LightDoc):
     set_name = 'sources'
-    def __init__(self, source_name=None, active=True, oid=None):
-        super(Source, self).__init__(oid=oid)
-
-        if oid == None:
-            # If oid is None, presume we're creating a new Source object
-            #
-            # Populate Source-specific attributes, not in LightDoc
-            self.data['active'] = active
-            self.data['source_name'] = source_name
-
-            # If we are initialized with a proper source_name, then
-            # set 'valid' to True
-            if self.data['source_name'] != None:
-                self.valid = True
+    source_name = LightStr(init="Test", required=True)
+    active = LightBool(init=True)
 
     def get_all():
         for source_obj in LightDoc.get_all(Source.set_name, Source):
@@ -67,7 +55,7 @@ class SourceSet(object):
         if req.content_length > 0:
             json_input = json.load(req.stream)
             if 'active' in json_input and 'source_name' in json_input:
-                src_obj = Source(json_input['source_name'], json_input['active'])
+                src_obj = Source(source_name=LightStr(init=json_input['source_name']), active=LightBool(init=json_input['active']))
                 src_obj.save()
                 res.body = json.dumps({'success': True, 'oid': src_obj.json()['id']})
             else:

--- a/light/photons/Sources.py
+++ b/light/photons/Sources.py
@@ -1,6 +1,59 @@
 import falcon
+import json
+from bson import ObjectId
+from light.light_types import LightDoc
 
 resources = ["SourceSet","SourceItem"]
+
+# A very simple entity schema that's built on top of the LightDoc and
+# contains the following additional fields:
+#
+# obj = {
+#    .....
+#    'active': boolean,
+#    'source_name': string
+#}
+#
+class Source(LightDoc):
+    set_name = 'sources'
+    def __init__(self, source_name=None, active=True, oid=None):
+        super(Source, self).__init__(set_name=Source.set_name, oid=oid)
+
+        if oid == None:
+            # If oid is None, presume we're creating a new Source object
+            #
+            # Populate Source-specific attributes, not it LightDoc
+            self.data['active'] = active
+            self.data['source_name'] = source_name
+
+            # If we are initialized with a proper source_name, then
+            # set 'valid' to True
+            if self.data['source_name'] != None:
+                self.valid = True
+
+    def get_all():
+        for source_obj in LightDoc.get_all(Source.set_name, Source):
+            yield source_obj
+
+    def json(self):
+        output_json = self.data
+        output_json['id'] = str(output_json['id'])
+        return output_json
+
+    def load(self, oid):
+        # First, load the content from disk into the JSON structure. This will
+        # only perform a data-conversion on the 'id' (str -> ObjectId)
+        super(Source, self).load(oid)
+
+        # XXX: It is up to you to perform any remaining data conversions to the
+        # fields managed by *this* class, here, after the initial load. Remember,
+        # set self.valid to False if the data loaded fails any validation, as the
+        # superclass load() function will have set it to True
+        #
+        # This could include loading data from within separate collections/tables/sets
+        # which represent sub-documents of this data, and which are represented as
+        # foreign keys within the core object's data fields.
+        #
 
 class SourceSet(object):
     def routes_set(self, app):
@@ -8,12 +61,29 @@ class SourceSet(object):
 
     def on_get(self, req, res):
         res.status = falcon.HTTP_200
-        res.body = ('Testing source access gets.')
+        res.body = json.dumps(list(x.json() for x in Source.get_all()))
+
+    def on_post(self, req, res):
+        if req.content_length > 0:
+            json_input = json.load(req.stream)
+            if 'active' in json_input and 'source_name' in json_input:
+                src_obj = Source(json_input['source_name'], json_input['active'])
+                src_obj.save()
+                res.body = json.dumps({'success': True, 'oid': src_obj.json()['id']})
+            else:
+                res.status = 500
+        else:
+            res.status = 500
 
 class SourceItem(object):
     def routes_set(self, app):
         app.add_route('/sources/{source}', self)
 
     def on_get(self, req, res, source):
-        res.status = falcon.HTTP_200
-        res.body = ('Testing source access gets, getting item {source}.'.format(source=source))
+        src_obj = Source(oid=source)
+        if src_obj.valid:
+            res.status = falcon.HTTP_200
+            res.body = json.dumps(src_obj.json())
+        else:
+            res.status = falcon.HTTP_500
+            res.body = json.dumps({'success': False, 'message': 'Unable to find source with id {objid}'.format(objid=source)})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+bson
 cython
 falcon --install-option="--no-binary :all:"
 gunicorn


### PR DESCRIPTION
Really quick draft of the following functionality:

- Database "driver" abstraction, with a basic implementation that's merely "JSON files in folders" as an impractical case useful for experimentation/debugging of small data sets
- POST to the <code>/sources/</code> endpoint to write a new object to disk (response contains the id)
- GET <code>/sources/{id}</code> now performs a lookup by id and gracefully handles cases where the object id isn't found
- GET <code>/sources/</code> returns a list of all the sources
- The <code>get_all</code> that's used for getting all objects in a set is implemented as a generator that passes data up through the abstraction layers to the caller
- An effort is made to minimize duplicate-reading of data by passing class types around as values
